### PR TITLE
Allow specifying time limit (including no time limit) as command line flag

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -329,6 +329,7 @@ void GTP::setup_default_parameters() {
     cfg_max_memory = UCTSearch::DEFAULT_MAX_MEMORY;
     cfg_max_playouts = UCTSearch::UNLIMITED_PLAYOUTS;
     cfg_max_visits = UCTSearch::UNLIMITED_PLAYOUTS;
+    cfg_time_limit = 60 * 60 * 100;
     // This will be overwriiten in initialize() after network size is known.
     cfg_max_tree_size = UCTSearch::DEFAULT_MAX_MEMORY;
     cfg_max_cache_ratio_percent = 10;

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -65,6 +65,7 @@ unsigned int cfg_num_threads;
 unsigned int cfg_batch_size;
 int cfg_max_playouts;
 int cfg_max_visits;
+int cfg_time_limit;
 size_t cfg_max_memory;
 size_t cfg_max_tree_size;
 int cfg_max_cache_ratio_percent;

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -84,6 +84,7 @@ extern unsigned int cfg_num_threads;
 extern unsigned int cfg_batch_size;
 extern int cfg_max_playouts;
 extern int cfg_max_visits;
+extern int cfg_time_limit;
 extern size_t cfg_max_memory;
 extern size_t cfg_max_tree_size;
 extern int cfg_max_cache_ratio_percent;

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -568,9 +568,9 @@ int main(int argc, char* argv[]) {
     auto maingame = std::make_unique<GameState>();
     if (cfg_time_limit == 0) {
       // Infinite time limit.
-      maingame.set_timecontrol(0, 1, 0, 0);
+      maingame->set_timecontrol(0, 1, 0, 0);
     } else {
-      maingame.set_timecontrol(cfg_time_limit, 0, 0, 0);
+      maingame->set_timecontrol(cfg_time_limit, 0, 0, 0);
     }
 
     /* set board limits */

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -425,7 +425,7 @@ static void parse_commandline(const int argc, const char* const argv[]) {
       cfg_time_limit = vm["timelimit"].as<int>();
       if (cfg_time_limit == 0
           && cfg_max_playouts == UCTSearch::UNLIMITED_PLAYOUTS
-          && cfg_max_visits == UCTSearch::ULIMITED_PLAYOUTS) {
+          && cfg_max_visits == UCTSearch::UNLIMITED_PLAYOUTS) {
         printf("--timelimit 0 is not allowed unless --playouts or --visits "
                "are specified.\n");
         exit(EXIT_FAILURE);
@@ -565,10 +565,13 @@ int main(int argc, char* argv[]) {
 
     init_global_objects();
 
-    // TODO muck with timecontrol here?
-    // game.set_timecontrol(maintime * 100, byotime * 100, byostones, 0);
     auto maingame = std::make_unique<GameState>();
-    game.set_time_control(cfg_time_limit, 0, 0, 0);
+    if (cfg_time_limit == 0) {
+      // Infinite time limit.
+      maingame.set_timecontrol(0, 1, 0, 0);
+    } else {
+      maingame.set_timecontrol(cfg_time_limit, 0, 0, 0);
+    }
 
     /* set board limits */
     maingame->init_game(BOARD_SIZE, KOMI);


### PR DESCRIPTION
Context: 
* Leela defaults to a 1 hour time limit (~30 seconds per move), but for more consistent results against Leela, we'd like to remove the time limit and only limit the number of visits so that Leela's play quality isn't affected by hardware
* The time limit can be changed with the GTP command `time_settings X Y Z` and can be removed altogether with `time_settings 0 1 0`. But we play KataGo against Leela using `twogtp`, and while `twogtp` does have a `-time` flag, that flag does not support removing the time limit 

Changes:
* Add `--timelimit` flag, which specifies Leela's time limit (defaulting to 1 hour). A time limit of 0 removes the time limit